### PR TITLE
Make most(if not all) float operations single precision

### DIFF
--- a/src/butter/Planed.hpp
+++ b/src/butter/Planed.hpp
@@ -28,9 +28,9 @@ public:
         int wh = width*height;
         int th_x = std::min(256, wh);
         int bl_x = (wh-1)/th_x + 1;
-        float weight_no_border = 0;
+        float weight_no_border = 0.0f;
         for (int i = 0; i < 2*gaussiansize+1; i++){
-            weight_no_border += std::expf(-(gaussiansize-i)*(gaussiansize-i)/(2*sigma*sigma))/(sqrtf(TAU*sigma*sigma));
+            weight_no_border += std::exp(-(gaussiansize-i)*(gaussiansize-i)/(2*sigma*sigma))/(std::sqrt(TAU*sigma*sigma));
         }
         horizontalBlur_Kernel<<<dim3(bl_x), dim3(th_x), 0, stream>>>(temp.mem_d, mem_d, width, height, border_ratio, weight_no_border, gaussiankernel, gaussiansize);
         verticalBlur_Kernel<<<dim3(bl_x), dim3(th_x), 0, stream>>>(mem_d, temp.mem_d, width, height, border_ratio, weight_no_border, gaussiankernel, gaussiansize);
@@ -42,9 +42,9 @@ public:
         int wh = width*height;
         int th_x = std::min(256, wh);
         int bl_x = (wh-1)/th_x + 1;
-        float weight_no_border = 0;
+        float weight_no_border = 0.0f;
         for (int i = 0; i < 2*gaussiansize+1; i++){
-            weight_no_border += std::expf(-(gaussiansize-i)*(gaussiansize-i)/(2*sigma*sigma))/(sqrtf(TAU*sigma*sigma));
+            weight_no_border += std::exp(-(gaussiansize-i)*(gaussiansize-i)/(2*sigma*sigma))/(std::sqrt(TAU*sigma*sigma));
         }
         horizontalBlur_Kernel<<<dim3(bl_x), dim3(th_x), 0, stream>>>(temp.mem_d, mem_d, width, height, border_ratio, weight_no_border, gaussiankernel, gaussiansize);
         verticalBlur_Kernel<<<dim3(bl_x), dim3(th_x), 0, stream>>>(dst.mem_d, temp.mem_d, width, height, border_ratio, weight_no_border, gaussiankernel, gaussiansize);

--- a/src/butter/Planed.hpp
+++ b/src/butter/Planed.hpp
@@ -30,7 +30,7 @@ public:
         int bl_x = (wh-1)/th_x + 1;
         float weight_no_border = 0;
         for (int i = 0; i < 2*gaussiansize+1; i++){
-            weight_no_border += std::exp(-(gaussiansize-i)*(gaussiansize-i)/(2*sigma*sigma))/(sqrt(2*PI*sigma*sigma));
+            weight_no_border += std::expf(-(gaussiansize-i)*(gaussiansize-i)/(2*sigma*sigma))/(sqrtf(TAU*sigma*sigma));
         }
         horizontalBlur_Kernel<<<dim3(bl_x), dim3(th_x), 0, stream>>>(temp.mem_d, mem_d, width, height, border_ratio, weight_no_border, gaussiankernel, gaussiansize);
         verticalBlur_Kernel<<<dim3(bl_x), dim3(th_x), 0, stream>>>(mem_d, temp.mem_d, width, height, border_ratio, weight_no_border, gaussiankernel, gaussiansize);
@@ -44,7 +44,7 @@ public:
         int bl_x = (wh-1)/th_x + 1;
         float weight_no_border = 0;
         for (int i = 0; i < 2*gaussiansize+1; i++){
-            weight_no_border += std::exp(-(gaussiansize-i)*(gaussiansize-i)/(2*sigma*sigma))/(sqrt(2*PI*sigma*sigma));
+            weight_no_border += std::expf(-(gaussiansize-i)*(gaussiansize-i)/(2*sigma*sigma))/(sqrtf(TAU*sigma*sigma));
         }
         horizontalBlur_Kernel<<<dim3(bl_x), dim3(th_x), 0, stream>>>(temp.mem_d, mem_d, width, height, border_ratio, weight_no_border, gaussiankernel, gaussiansize);
         verticalBlur_Kernel<<<dim3(bl_x), dim3(th_x), 0, stream>>>(dst.mem_d, temp.mem_d, width, height, border_ratio, weight_no_border, gaussiankernel, gaussiansize);

--- a/src/butter/colors.hpp
+++ b/src/butter/colors.hpp
@@ -1,14 +1,14 @@
 namespace butter{
 
 __device__ float gamma(float v) {
-    return fmaf(19.245013259874995f, logf(v + 9.9710635769299145f), -23.16046239805755f);
+    return fmaf(19.245013259874995f, logf(v + 9.9710635769299145), -23.16046239805755f);
 }
 
 __device__ inline void rgb_to_linrgbfunc(float& a){
     if (a > 0.04045f){
-        a = powf(((a+0.055f)/(1.055f)), 2.4f);
+        a = powf(((a+0.055)*(1.0/1.055)), 2.4f);
     } else {
-        a = a/12.92f;
+        a *= 1.0/12.92;
     }
 }
 

--- a/src/butter/colors.hpp
+++ b/src/butter/colors.hpp
@@ -1,14 +1,14 @@
 namespace butter{
 
 __device__ float gamma(float v) {
-    return fmaf(19.245013259874995f, logf(v + 9.9710635769299145), -23.16046239805755);
+    return fmaf(19.245013259874995f, logf(v + 9.9710635769299145f), -23.16046239805755f);
 }
 
 __device__ inline void rgb_to_linrgbfunc(float& a){
-    if (a > 0.04045){
-        a = powf(((a+0.055)/(1+0.055)), 2.4f);
+    if (a > 0.04045f){
+        a = powf(((a+0.055f)/(1.055f)), 2.4f);
     } else {
-        a = a/12.92;
+        a = a/12.92f;
     }
 }
 
@@ -22,25 +22,25 @@ __global__ void linearrgb_kernel(float* src1, float* src2, float* src3, int widt
 
 __device__ inline void butterOpsinAbsorbance(float3& a, bool clamp = false){
     float3 out;
-    out.x = fmaf(0.29956550340058319, a.x,
-    fmaf(0.63373087833825936, a.y,
-    fmaf(0.077705617820981968, a.z,
-    1.7557483643287353)));
+    out.x = fmaf(0.29956550340058319f, a.x,
+    fmaf(0.63373087833825936f, a.y,
+    fmaf(0.077705617820981968f, a.z,
+    1.7557483643287353f)));
 
-    out.y = fmaf(0.22158691104574774, a.x,
-    fmaf(0.69391388044116142, a.y,
-    fmaf(0.0987313588422, a.z,
-    1.7557483643287353)));
+    out.y = fmaf(0.22158691104574774f, a.x,
+    fmaf(0.69391388044116142f, a.y,
+    fmaf(0.0987313588422f, a.z,
+    1.7557483643287353f)));
 
-    out.z = fmaf(0.02, a.x,
-    fmaf(0.02, a.y,
-    fmaf(0.20480129041026129, a.z,
-    12.226454707163354)));
+    out.z = fmaf(0.02f, a.x,
+    fmaf(0.02f, a.y,
+    fmaf(0.20480129041026129f, a.z,
+    12.226454707163354f)));
 
     if (clamp){
-        out.x = max(out.x, 1.7557483643287353);
-        out.y = max(out.y, 1.7557483643287353);
-        out.z = max(out.z, 12.226454707163354);
+        out.x = max(out.x, 1.7557483643287353f);
+        out.y = max(out.y, 1.7557483643287353f);
+        out.z = max(out.z, 12.226454707163354f);
     }
 
     a = out;
@@ -84,7 +84,7 @@ void opsinDynamicsImage(Plane_d src[3], Plane_d temp[3], Plane_d temp2, float* g
     linearrgb_kernel<<<dim3(bl_x), dim3(th_x), 0, src[0].stream>>>(src[0].mem_d, src[1].mem_d, src[2].mem_d, width, height);
     //printf("initial adress: %llu\n", (unsigned long long)src[0].mem_d);
     for (int i = 0; i < 3; i++){
-        src[i].blur(temp[i], temp2, 1.2f, 0.0, gaussiankernel);
+        src[i].blur(temp[i], temp2, 1.2f, 0.0f, gaussiankernel);
     }
     opsinDynamicsImage_kernel<<<dim3(bl_x), dim3(th_x), 0, src[0].stream>>>(src[0].mem_d, src[1].mem_d, src[2].mem_d, temp[0].mem_d, temp[1].mem_d, temp[2].mem_d, width, height, intensity_multiplier);
     GPU_CHECK(hipGetLastError());

--- a/src/butter/combineMasks.hpp
+++ b/src/butter/combineMasks.hpp
@@ -5,7 +5,7 @@ __device__ float MaskY(float delta) {
     const float scaler = 0.451936922203f;
     const float mul = 2.5485944793f;
     const float c = mul / ((scaler * delta) + offset);
-    const float retval = (1.0f + c)/(0.79079917404f*17.83f);
+    const float retval = (1.0 + c)*(1.0/(0.79079917404f*17.83f));
     return retval * retval;
 }
 
@@ -14,7 +14,7 @@ __device__ float MaskDcY(float delta) {
     const float scaler = 3.87449418804f;
     const float mul = 0.505054525019f;
     const float c = mul / ((scaler * delta) + offset);
-    const float retval = (1.0f + c)/(0.79079917404f*17.83f);
+    const float retval = (1.0 + c)*(1.0/(0.79079917404f*17.83f));
     return retval * retval;
 }
 

--- a/src/butter/combineMasks.hpp
+++ b/src/butter/combineMasks.hpp
@@ -1,20 +1,20 @@
 namespace butter{
 
 __device__ float MaskY(float delta) {
-    const float offset = 0.829591754942;
-    const float scaler = 0.451936922203;
-    const float mul = 2.5485944793;
+    const float offset = 0.829591754942f;
+    const float scaler = 0.451936922203f;
+    const float mul = 2.5485944793f;
     const float c = mul / ((scaler * delta) + offset);
-    const float retval = (1.0 + c)/(0.79079917404f*17.83f);
+    const float retval = (1.0f + c)/(0.79079917404f*17.83f);
     return retval * retval;
 }
 
 __device__ float MaskDcY(float delta) {
-    const float offset = 0.20025578522;
-    const float scaler = 3.87449418804;
-    const float mul = 0.505054525019;
+    const float offset = 0.20025578522f;
+    const float scaler = 3.87449418804f;
+    const float mul = 0.505054525019f;
     const float c = mul / ((scaler * delta) + offset);
-    const float retval = (1.0 + c)/(0.79079917404f*17.83f);
+    const float retval = (1.0f + c)/(0.79079917404f*17.83f);
     return retval * retval;
 }
 

--- a/src/butter/diffnorms.hpp
+++ b/src/butter/diffnorms.hpp
@@ -10,9 +10,9 @@ __global__ void sumreduce(float* dst, float* src, int width){
     __shared__ float sharedmem[1024*3];
 
     if (x >= width){
-        sharedmem[thx] = 0;
-        sharedmem[1024+thx] = 0;
-        sharedmem[1024*2+thx] = 0;
+        sharedmem[thx] = 0.0f;
+        sharedmem[1024+thx] = 0.0f;
+        sharedmem[1024*2+thx] = 0.0f;
     } else {
         sharedmem[thx] = src[x];
         sharedmem[1024+thx] = src[x+width];
@@ -47,13 +47,13 @@ __global__ void sumreducenorm(float* dst, float* src, int width){
     __shared__ float sharedmem[1024*3];
 
     if (x >= width){
-        sharedmem[thx] = 0;
-        sharedmem[1024+thx] = 0;
-        sharedmem[1024*2+thx] = 0;
+        sharedmem[thx] = 0.0f;
+        sharedmem[1024+thx] = 0.0f;
+        sharedmem[1024*2+thx] = 0.0f;
     } else {
-        sharedmem[thx] = powf(abs(src[x]), 2);
-        sharedmem[1024+thx] = powf(abs(src[x]), 2);
-        sharedmem[1024*2+thx] = abs(src[x]);
+        sharedmem[thx] = powf(fabs(src[x]), 2);
+        sharedmem[1024+thx] = powf(fabs(src[x]), 2);
+        sharedmem[1024*2+thx] = fabs(src[x]);
     }
     __syncthreads();
     //now we need to do some pointer jumping to regroup every block sums;
@@ -106,19 +106,19 @@ std::tuple<float, float, float> diffmapscore(float* diffmap, float* temp, float*
 
     for (int i = 0; i < width; i++){
         if (first){
-            resnorm2 += std::pow(std::abs(back_to_cpu[i]), 2);
-            resnorm3 += std::pow(std::abs(back_to_cpu[i]), 3);
-            resnorminf = std::max(resnorminf, std::abs(back_to_cpu[i]));
+            resnorm2 += std::powf(std::fabsf(back_to_cpu[i]), 2);
+            resnorm3 += std::powf(std::fabsf(back_to_cpu[i]), 3);
+            resnorminf = std::max(resnorminf, std::fabsf(back_to_cpu[i]));
         } else {
-            resnorm2 += std::abs(back_to_cpu[i]);
-            resnorm3 += std::abs(back_to_cpu[i+width]);
-            resnorminf = std::max(resnorminf, std::abs(back_to_cpu[i+2*width]));
+            resnorm2 += std::fabsf(back_to_cpu[i]);
+            resnorm3 += std::fabsf(back_to_cpu[i+width]);
+            resnorminf = std::max(resnorminf, std::fabsf(back_to_cpu[i+2*width]));
         }
     }
 
     free(back_to_cpu);
-    resnorm2 = std::pow(resnorm2/basewidth, 1./2.);
-    resnorm3 = std::pow(resnorm3/basewidth, 1./3.);
+    resnorm2 = std::powf(resnorm2/basewidth, 1.0f/2.0f);
+    resnorm3 = std::powf(resnorm3/basewidth, 1.0f/3.0f);
     return std::make_tuple(resnorm2, resnorm3, resnorminf);
 }
 

--- a/src/butter/diffnorms.hpp
+++ b/src/butter/diffnorms.hpp
@@ -96,9 +96,9 @@ std::tuple<float, float, float> diffmapscore(float* diffmap, float* temp, float*
     }
     float* back_to_cpu = (float*)malloc(sizeof(float)*width*3);
     if (!back_to_cpu) throw std::bad_alloc();
-    float resnorm2 = 0;
-    float resnorm3 = 0;
-    float resnorminf = 0;
+    float resnorm2 = 0.0f;
+    float resnorm3 = 0.0f;
+    float resnorminf = 0.0f;
     hipMemcpyDtoHAsync(back_to_cpu, src, sizeof(float)*width*3, stream);
 
     hipEventRecord(event_d, stream); //place an event in the stream at the end of all our operations
@@ -106,19 +106,19 @@ std::tuple<float, float, float> diffmapscore(float* diffmap, float* temp, float*
 
     for (int i = 0; i < width; i++){
         if (first){
-            resnorm2 += std::powf(std::fabsf(back_to_cpu[i]), 2);
-            resnorm3 += std::powf(std::fabsf(back_to_cpu[i]), 3);
-            resnorminf = std::max(resnorminf, std::fabsf(back_to_cpu[i]));
+            resnorm2 += std::pow(std::abs(back_to_cpu[i]), 2);
+            resnorm3 += std::pow(std::abs(back_to_cpu[i]), 3);
+            resnorminf = std::max(resnorminf, std::abs(back_to_cpu[i]));
         } else {
-            resnorm2 += std::fabsf(back_to_cpu[i]);
-            resnorm3 += std::fabsf(back_to_cpu[i+width]);
-            resnorminf = std::max(resnorminf, std::fabsf(back_to_cpu[i+2*width]));
+            resnorm2 += std::abs(back_to_cpu[i]);
+            resnorm3 += std::abs(back_to_cpu[i+width]);
+            resnorminf = std::max(resnorminf, std::abs(back_to_cpu[i+2*width]));
         }
     }
 
     free(back_to_cpu);
-    resnorm2 = std::powf(resnorm2/basewidth, 1.0f/2.0f);
-    resnorm3 = std::powf(resnorm3/basewidth, 1.0f/3.0f);
+    resnorm2 = std::powf(resnorm2/basewidth, 1.0/2.0);
+    resnorm3 = std::pow(resnorm3/basewidth, 1.0/3.0);
     return std::make_tuple(resnorm2, resnorm3, resnorminf);
 }
 

--- a/src/butter/diffnorms.hpp
+++ b/src/butter/diffnorms.hpp
@@ -51,9 +51,9 @@ __global__ void sumreducenorm(float* dst, float* src, int width){
         sharedmem[1024+thx] = 0.0f;
         sharedmem[1024*2+thx] = 0.0f;
     } else {
-        sharedmem[thx] = powf(fabs(src[x]), 2);
-        sharedmem[1024+thx] = powf(fabs(src[x]), 2);
-        sharedmem[1024*2+thx] = fabs(src[x]);
+        sharedmem[thx] = powf(abs(src[x]), 2);
+        sharedmem[1024+thx] = powf(abs(src[x]), 2);
+        sharedmem[1024*2+thx] = abs(src[x]);
     }
     __syncthreads();
     //now we need to do some pointer jumping to regroup every block sums;

--- a/src/butter/downupsample.hpp
+++ b/src/butter/downupsample.hpp
@@ -10,12 +10,12 @@ __global__ void downsamplekernel(float* src, float* dst, int width, int height){
 
     if (x >= neww || y >= newh) return;
 
-    dst[y * neww + x] = 0;
+    dst[y * neww + x] = 0.0f;
     dst[y * neww + x] += src[min((int)(2*y), (int)(height-1)) * width + min((int)(2*x), (int)(width-1))];
     dst[y * neww + x] += src[min((int)(2*y + 1), (int)(height-1)) * width + min((int)(2*x), (int)(width-1))];
     dst[y * neww + x] += src[min((int)(2*y), (int)(height-1)) * width + min((int)(2*x+1), (int)(width-1))];
     dst[y * neww + x] += src[min((int)(2*y + 1), (int)(height-1)) * width + min((int)(2*x+1), (int)(width-1))];
-    dst[y * neww + x] /= 4;
+    dst[y * neww + x] *= 0.25f;
     //if ((y*2+1)*width + x*2 == 10000) printf("got %f\n", dst[y*neww + x]);
 }
 
@@ -38,12 +38,12 @@ __global__ void addsupersample2X_kernel(float* diffmap, float* diffmapsmall, int
 
     //int newh = (height-1)/2 + 1;
     int neww = (width-1)/2 + 1;
-
+    
     if (x >= width || y >= height) return;
 
     //if (y*width+x == 1841628) printf("small got %f and normal got %f\n", diffmapsmall[(y/2)*neww+x/2], diffmap[y*width+x]);
 
-    diffmap[y*width+x] *= 1.0f - 0.3f*w;
+    diffmap[y*width+x] *= 1.0 - 0.3*w;
     diffmap[y*width+x] += w*diffmapsmall[(y/2)*neww+x/2];
 }
 

--- a/src/butter/downupsample.hpp
+++ b/src/butter/downupsample.hpp
@@ -43,7 +43,7 @@ __global__ void addsupersample2X_kernel(float* diffmap, float* diffmapsmall, int
 
     //if (y*width+x == 1841628) printf("small got %f and normal got %f\n", diffmapsmall[(y/2)*neww+x/2], diffmap[y*width+x]);
 
-    diffmap[y*width+x] *= 1. - 0.3*w;
+    diffmap[y*width+x] *= 1.0f - 0.3f*w;
     diffmap[y*width+x] += w*diffmapsmall[(y/2)*neww+x/2];
 }
 

--- a/src/butter/gaussianblur.hpp
+++ b/src/butter/gaussianblur.hpp
@@ -3,7 +3,7 @@ namespace butter{
 __global__ void loadGaussianKernel(float* gaussiankernel, int gaussiansize, float sigma){
     int x = threadIdx.x;
     if (x > 2*gaussiansize) return;
-    gaussiankernel[x] = exp(-(gaussiansize-x)*(gaussiansize-x)/(2*sigma*sigma))/(sqrt(TAU*sigma*sigma));
+    gaussiankernel[x] = expf(-(gaussiansize-x)*(gaussiansize-x)/(2*sigma*sigma))/(sqrtf(TAU*sigma*sigma));
 }
 
 //transpose the result at the end

--- a/src/butter/gaussianblur.hpp
+++ b/src/butter/gaussianblur.hpp
@@ -1,9 +1,9 @@
 namespace butter{
 
 __global__ void loadGaussianKernel(float* gaussiankernel, int gaussiansize, float sigma){
-    int x = threadIdx.x;
+    const int x = threadIdx.x;
     if (x > 2*gaussiansize) return;
-    gaussiankernel[x] = expf(-(gaussiansize-x)*(gaussiansize-x)/(2*sigma*sigma))/(sqrtf(TAU*sigma*sigma));
+    gaussiankernel[x] = expf(-(gaussiansize-x)*(gaussiansize-x)/(2*sigma*sigma))/(sqrt(TAU*sigma*sigma));
 }
 
 //transpose the result at the end
@@ -15,9 +15,9 @@ __global__ void horizontalBlur_Kernel(float* dst, float* src, int w, int h, floa
 
     int current_line = x/w;
 
-    float weight = 0;
+    float weight = 0.0f;
 
-    float out = 0;
+    float out = 0.0f;
     for (int i = max(x-gaussiansize, current_line*w); i <= min(x+gaussiansize, (current_line+1)*w-1); i++){
         const float gauss = gaussiankernel[gaussiansize+i-x];
         out += src[i]*gauss;
@@ -35,15 +35,15 @@ __global__ void verticalBlur_Kernel(float* dst, float* src, int w, int h, float 
     int current_line = x/w;
     int current_column = x%w;
 
-    float weight = 0;
+    float weight = 0.0f;
 
-    float out = 0;
+    float out = 0.0f;
     for (int i = max(current_line-gaussiansize, 0); i <= min(current_line+gaussiansize, h-1); i++){
         out += src[i * w + current_column]*gaussiankernel[gaussiansize+i-current_line];
         weight += gaussiankernel[gaussiansize+i-current_line];
         //if (threadIdx.x == 0) printf("%f at %d\n", gaussiankernel[gaussiansize+i-current_line], gaussiansize+i-current_line);
     }
-    float resweight = (1.f-border_ratio)*weight + border_ratio*weight_no_border;
+    float resweight = (1.0f-border_ratio)*weight + border_ratio*weight_no_border;
     dst[x] = out/resweight;
     //printf("from %f to %f with resweight %f, weight %f, border_ratio %f, weight_no_border %f\n", src[x], dst[x], resweight, weight, border_ratio, weight_no_border);
 }

--- a/src/butter/gaussianblur.hpp
+++ b/src/butter/gaussianblur.hpp
@@ -23,7 +23,7 @@ __global__ void horizontalBlur_Kernel(float* dst, float* src, int w, int h, floa
         out += src[i]*gauss;
         weight += gauss;
     }
-    dst[x] = out*(1.f/((1.f-border_ratio)*weight + border_ratio*weight_no_border));
+    dst[x] = out*(1.0f/((1.0f-border_ratio)*weight + border_ratio*weight_no_border));
 }
 
 __launch_bounds__(256)

--- a/src/butter/gaussianblur.hpp
+++ b/src/butter/gaussianblur.hpp
@@ -3,7 +3,7 @@ namespace butter{
 __global__ void loadGaussianKernel(float* gaussiankernel, int gaussiansize, float sigma){
     int x = threadIdx.x;
     if (x > 2*gaussiansize) return;
-    gaussiankernel[x] = exp(-(gaussiansize-x)*(gaussiansize-x)/(2*sigma*sigma))/(sqrt(2*PI*sigma*sigma));
+    gaussiankernel[x] = exp(-(gaussiansize-x)*(gaussiansize-x)/(2*sigma*sigma))/(sqrt(TAU*sigma*sigma));
 }
 
 //transpose the result at the end

--- a/src/butter/main.hpp
+++ b/src/butter/main.hpp
@@ -60,11 +60,11 @@ Plane_d getdiffmap(Plane_d* src1_d, Plane_d* src2_d, float* mem_d, int width, in
 
     const float wHfMalta = 18.7237414387f;
     const float norm1Hf = 4498534.45232f;
-    MaltaDiffMapLF(hf1[1].mem_d, hf2[1].mem_d, block_diff_ac[1].mem_d, width, height, wHfMalta * sqrt(hf_asymmetry_), wHfMalta / sqrt(hf_asymmetry_), norm1Hf, stream);
+    MaltaDiffMapLF(hf1[1].mem_d, hf2[1].mem_d, block_diff_ac[1].mem_d, width, height, wHfMalta * std::sqrt(hf_asymmetry_), wHfMalta / std::sqrt(hf_asymmetry_), norm1Hf, stream);
 
     const float wHfMaltaX = 6923.99476109f;
     const float norm1HfX = 8051.15833247f;
-    MaltaDiffMapLF(hf1[0].mem_d, hf2[0].mem_d, block_diff_ac[0].mem_d, width, height, wHfMaltaX * sqrt(hf_asymmetry_), wHfMaltaX / sqrt(hf_asymmetry_), norm1HfX, stream);
+    MaltaDiffMapLF(hf1[0].mem_d, hf2[0].mem_d, block_diff_ac[0].mem_d, width, height, wHfMaltaX * std::sqrt(hf_asymmetry_), wHfMaltaX / std::sqrt(hf_asymmetry_), norm1HfX, stream);
 
     const float wMfMalta = 37.0819870399f;
     const float norm1Mf = 130262059.556f;
@@ -78,7 +78,7 @@ Plane_d getdiffmap(Plane_d* src1_d, Plane_d* src2_d, float* mem_d, int width, in
       400.0f,         1.50815703118f,  0.0f,
       2150.0f,        10.6195433239f,  16.2176043152f,
       29.2353797994f, 0.844626970982f, 0.703646627719f,
-  };
+    };
 
     //const float maxclamp = 85.7047444518;
     //const float kSigmaHfX = 10.6666499623;
@@ -169,7 +169,7 @@ std::tuple<float, float, float> butterprocess(const uint8_t *dstp, int dststride
     nmem_d = mem_d+9*width*height;
     Plane_d diffmapsmall = getdiffmap(nsrc1_d, nsrc2_d, nmem_d+6*nwidth*nheight, nwidth, nheight, intensity_multiplier, maxshared, gaussiankernel_dmem, stream);
 
-    addsupersample2X(diffmap.mem_d, diffmapsmall.mem_d, width, height, 0.5, stream);
+    addsupersample2X(diffmap.mem_d, diffmapsmall.mem_d, width, height, 0.5f, stream);
 
     //diffmap is in its final form
     if (dstp != NULL){

--- a/src/butter/main.hpp
+++ b/src/butter/main.hpp
@@ -48,36 +48,36 @@ Plane_d getdiffmap(Plane_d* src1_d, Plane_d* src2_d, float* mem_d, int width, in
         block_diff_dc[c].fill0();
     }
 
-    const float hf_asymmetry_ = 0.8;
+    const float hf_asymmetry_ = 0.8f;
 
-    const float wUhfMalta = 1.10039032555;
-    const float norm1Uhf = 71.7800275169;
+    const float wUhfMalta = 1.10039032555f;
+    const float norm1Uhf = 71.7800275169f;
     MaltaDiffMap(uhf1[1].mem_d, uhf2[1].mem_d, block_diff_ac[1].mem_d, width, height, wUhfMalta * hf_asymmetry_, wUhfMalta / hf_asymmetry_, norm1Uhf, stream);
 
-    const float wUhfMaltaX = 173.5;
-    const float norm1UhfX = 5.0;
+    const float wUhfMaltaX = 173.5f;
+    const float norm1UhfX = 5.0f;
     MaltaDiffMap(uhf1[0].mem_d, uhf2[0].mem_d, block_diff_ac[0].mem_d, width, height, wUhfMaltaX * hf_asymmetry_, wUhfMaltaX / hf_asymmetry_, norm1UhfX, stream);
 
-    const float wHfMalta = 18.7237414387;
-    const float norm1Hf = 4498534.45232;
+    const float wHfMalta = 18.7237414387f;
+    const float norm1Hf = 4498534.45232f;
     MaltaDiffMapLF(hf1[1].mem_d, hf2[1].mem_d, block_diff_ac[1].mem_d, width, height, wHfMalta * sqrt(hf_asymmetry_), wHfMalta / sqrt(hf_asymmetry_), norm1Hf, stream);
 
-    const float wHfMaltaX = 6923.99476109;
-    const float norm1HfX = 8051.15833247;
+    const float wHfMaltaX = 6923.99476109f;
+    const float norm1HfX = 8051.15833247f;
     MaltaDiffMapLF(hf1[0].mem_d, hf2[0].mem_d, block_diff_ac[0].mem_d, width, height, wHfMaltaX * sqrt(hf_asymmetry_), wHfMaltaX / sqrt(hf_asymmetry_), norm1HfX, stream);
 
-    const float wMfMalta = 37.0819870399;
-    const float norm1Mf = 130262059.556;
+    const float wMfMalta = 37.0819870399f;
+    const float norm1Mf = 130262059.556f;
     MaltaDiffMapLF(mf1[1].mem_d, mf2[1].mem_d, block_diff_ac[1].mem_d, width, height, wMfMalta, wMfMalta, norm1Mf, stream);
 
-    const float wMfMaltaX = 8246.75321353;
-    const float norm1MfX = 1009002.70582;
+    const float wMfMaltaX = 8246.75321353f;
+    const float norm1MfX = 1009002.70582f;
     MaltaDiffMapLF(mf1[0].mem_d, mf2[0].mem_d, block_diff_ac[0].mem_d, width, height, wMfMaltaX, wMfMaltaX, norm1MfX, stream);
 
     const float wmul[9] = {
-      400.0,         1.50815703118,  0,
-      2150.0,        10.6195433239,  16.2176043152,
-      29.2353797994, 0.844626970982, 0.703646627719,
+      400.0f,         1.50815703118f,  0.0f,
+      2150.0f,        10.6195433239f,  16.2176043152f,
+      29.2353797994f, 0.844626970982f, 0.703646627719f,
   };
 
     //const float maxclamp = 85.7047444518;
@@ -313,7 +313,7 @@ static void VS_CC butterCreate(const VSMap *in, VSMap *out, void *userData, VSCo
     int error;
     d.intensity_multiplier = vsapi->mapGetFloat(in, "intensity_multiplier", 0, &error);
     if (error != peSuccess){
-        d.intensity_multiplier = 80;
+        d.intensity_multiplier = 80.0f;
     }
     d.diffmap = vsapi->mapGetInt(in, "distmap", 0, &error);
     if (error != peSuccess){

--- a/src/butter/maltaDiff.hpp
+++ b/src/butter/maltaDiff.hpp
@@ -538,7 +538,7 @@ __global__ void MaltaDiffMap_Kernel(const float* lum0, const float* lum1, float*
             continue;
         }
 
-        const float absval = 0.5f * fabs(lum0[worky*width + workx]) + 0.5f * fabs(lum1[worky*width + workx]);
+        const float absval = 0.5f * abs(lum0[worky*width + workx]) + 0.5f * abs(lum1[worky*width + workx]);
         const float diff = lum0[worky*width + workx] - lum1[worky*width + workx];
         const float scaler = norm2_0gt1 / (norm1 + absval);
 
@@ -546,7 +546,7 @@ __global__ void MaltaDiffMap_Kernel(const float* lum0, const float* lum1, float*
         diffs[i] = scaler * diff;
 
         const float scaler2 = norm2_0lt1 / (static_cast<float>(norm1) + absval);
-        const float fabs0 = fabs(lum0[worky*width + workx]);
+        const float fabs0 = abs(lum0[worky*width + workx]);
 
         // Secondary half-open quadratic objectives.
         const float too_small = 0.55f * fabs0;
@@ -612,7 +612,7 @@ __global__ void MaltaDiffMapLF_Kernel(const float* lum0, const float* lum1, floa
             continue;
         }
 
-        const float absval = 0.5f * fabs(lum0[worky*width + workx]) + 0.5f * fabs(lum1[worky*width + workx]);
+        const float absval = 0.5f * abs(lum0[worky*width + workx]) + 0.5f * abs(lum1[worky*width + workx]);
         const float diff = lum0[worky*width + workx] - lum1[worky*width + workx];
         const float scaler = norm2_0gt1 / (norm1 + absval);
 
@@ -620,7 +620,7 @@ __global__ void MaltaDiffMapLF_Kernel(const float* lum0, const float* lum1, floa
         diffs[i] = scaler * diff;
 
         const float scaler2 = norm2_0lt1 / (static_cast<float>(norm1) + absval);
-        const float fabs0 = fabs(lum0[worky*width + workx]);
+        const float fabs0 = abs(lum0[worky*width + workx]);
 
         // Secondary half-open quadratic objectives.
         const float too_small = 0.55f * fabs0;

--- a/src/butter/maltaDiff.hpp
+++ b/src/butter/maltaDiff.hpp
@@ -516,11 +516,11 @@ __global__ void MaltaDiffMap_Kernel(const float* lum0, const float* lum1, float*
     const int x = threadIdx.x + blockIdx.x*blockDim.x;
     const int y = threadIdx.y + blockIdx.y*blockDim.y;
 
-    const float kWeight0 = 0.5;
-    const float kWeight1 = 0.33;
+    const float kWeight0 = 0.5f;
+    const float kWeight1 = 0.33f;
 
-    const float w_pre0gt1 = mulli * sqrtf(kWeight0 * w_0gt1) / (len * 2 + 1);
-    const float w_pre0lt1 = mulli * sqrtf(kWeight1 * w_0lt1) / (len * 2 + 1);
+    const float w_pre0gt1 = mulli * sqrtf(kWeight0 * w_0gt1) / (len * 2.0f + 1.0f);
+    const float w_pre0lt1 = mulli * sqrtf(kWeight1 * w_0lt1) / (len * 2.0f + 1.0f);
     const float norm2_0gt1 = w_pre0gt1 * norm1;
     const float norm2_0lt1 = w_pre0lt1 * norm1;
 
@@ -538,7 +538,7 @@ __global__ void MaltaDiffMap_Kernel(const float* lum0, const float* lum1, float*
             continue;
         }
 
-        const float absval = 0.5 * abs(lum0[worky*width + workx]) + 0.5 * abs(lum1[worky*width + workx]);
+        const float absval = 0.5f * fabs(lum0[worky*width + workx]) + 0.5f * fabs(lum1[worky*width + workx]);
         const float diff = lum0[worky*width + workx] - lum1[worky*width + workx];
         const float scaler = norm2_0gt1 / (norm1 + absval);
 
@@ -546,11 +546,11 @@ __global__ void MaltaDiffMap_Kernel(const float* lum0, const float* lum1, float*
         diffs[i] = scaler * diff;
 
         const float scaler2 = norm2_0lt1 / (static_cast<float>(norm1) + absval);
-        const float fabs0 = abs(lum0[worky*width + workx]);
+        const float fabs0 = fabs(lum0[worky*width + workx]);
 
         // Secondary half-open quadratic objectives.
-        const float too_small = 0.55 * fabs0;
-        const float too_big = 1.05 * fabs0;
+        const float too_small = 0.55f * fabs0;
+        const float too_big = 1.05f * fabs0;
 
         float impact = 0;
 
@@ -590,8 +590,8 @@ __global__ void MaltaDiffMapLF_Kernel(const float* lum0, const float* lum1, floa
     const int x = threadIdx.x + blockIdx.x*blockDim.x;
     const int y = threadIdx.y + blockIdx.y*blockDim.y;
 
-    const float kWeight0 = 0.5;
-    const float kWeight1 = 0.33;
+    const float kWeight0 = 0.5f;
+    const float kWeight1 = 0.33f;
 
     const float w_pre0gt1 = mulli * sqrtf(kWeight0 * w_0gt1) / (len * 2 + 1);
     const float w_pre0lt1 = mulli * sqrtf(kWeight1 * w_0lt1) / (len * 2 + 1);
@@ -612,7 +612,7 @@ __global__ void MaltaDiffMapLF_Kernel(const float* lum0, const float* lum1, floa
             continue;
         }
 
-        const float absval = 0.5 * abs(lum0[worky*width + workx]) + 0.5 * abs(lum1[worky*width + workx]);
+        const float absval = 0.5f * fabs(lum0[worky*width + workx]) + 0.5f * fabs(lum1[worky*width + workx]);
         const float diff = lum0[worky*width + workx] - lum1[worky*width + workx];
         const float scaler = norm2_0gt1 / (norm1 + absval);
 
@@ -620,11 +620,11 @@ __global__ void MaltaDiffMapLF_Kernel(const float* lum0, const float* lum1, floa
         diffs[i] = scaler * diff;
 
         const float scaler2 = norm2_0lt1 / (static_cast<float>(norm1) + absval);
-        const float fabs0 = abs(lum0[worky*width + workx]);
+        const float fabs0 = fabs(lum0[worky*width + workx]);
 
         // Secondary half-open quadratic objectives.
-        const float too_small = 0.55 * fabs0;
-        const float too_big = 1.05 * fabs0;
+        const float too_small = 0.55f * fabs0;
+        const float too_big = 1.05f * fabs0;
 
         float impact = 0;
 

--- a/src/butter/maltaDiff.hpp
+++ b/src/butter/maltaDiff.hpp
@@ -3,7 +3,7 @@ namespace butter{
 //maltaUnit functions are copy pasted from google butteraugli
 __device__ float MaltaUnitLF(float* d, const int xs) {
     const int xs3 = 3 * xs;
-    float retval = 0;
+    float retval = 0.0f;
     {
         // x grows, y constant
         float sum =
@@ -234,7 +234,7 @@ __device__ float MaltaUnitLF(float* d, const int xs) {
 
 __device__ float MaltaUnit(float* d, const int xs) {
     const int xs3 = 3 * xs;
-    float retval = 0;
+    float retval = 0.0f;
     {
         // x grows, y constant
         float sum =
@@ -519,8 +519,9 @@ __global__ void MaltaDiffMap_Kernel(const float* lum0, const float* lum1, float*
     const float kWeight0 = 0.5f;
     const float kWeight1 = 0.33f;
 
-    const float w_pre0gt1 = mulli * sqrtf(kWeight0 * w_0gt1) / (len * 2.0f + 1.0f);
-    const float w_pre0lt1 = mulli * sqrtf(kWeight1 * w_0lt1) / (len * 2.0f + 1.0f);
+    const float len2 = len * 2.0f + 1.0f;
+    const float w_pre0gt1 = mulli * sqrtf(kWeight0 * w_0gt1) / len2;
+    const float w_pre0lt1 = mulli * sqrtf(kWeight1 * w_0lt1) / len2;
     const float norm2_0gt1 = w_pre0gt1 * norm1;
     const float norm2_0lt1 = w_pre0lt1 * norm1;
 
@@ -534,7 +535,7 @@ __global__ void MaltaDiffMap_Kernel(const float* lum0, const float* lum1, float*
     for (int i = serialind; i < 24*24; i += serialstride){
         int workx = topleftx + i%24; int worky = toplefty + i/24;
         if (workx < 0 || workx >= width || worky < 0 || worky >= height){
-            diffs[i] = 0;
+            diffs[i] = 0.0f;
             continue;
         }
 
@@ -549,12 +550,12 @@ __global__ void MaltaDiffMap_Kernel(const float* lum0, const float* lum1, float*
         const float fabs0 = abs(lum0[worky*width + workx]);
 
         // Secondary half-open quadratic objectives.
-        const float too_small = 0.55f * fabs0;
-        const float too_big = 1.05f * fabs0;
+        const float too_small = 0.55 * fabs0;
+        const float too_big = 1.05 * fabs0;
 
-        float impact = 0;
+        float impact = 0.0f;
 
-        if (lum0[worky*width + workx] < 0){
+        if (lum0[worky*width + workx] < 0.0f){
             if (lum1[worky*width + workx] > -too_small){
                 impact = lum1[worky*width + workx] + too_small;
             } else if (lum1[worky*width + workx] < -too_big){
@@ -569,7 +570,7 @@ __global__ void MaltaDiffMap_Kernel(const float* lum0, const float* lum1, float*
         }
         impact *= scaler2;
 
-        if (diff < 0){
+        if (diff < 0.0f){
             diffs[i] -= impact;
         } else {
             diffs[i] += impact;
@@ -593,8 +594,9 @@ __global__ void MaltaDiffMapLF_Kernel(const float* lum0, const float* lum1, floa
     const float kWeight0 = 0.5f;
     const float kWeight1 = 0.33f;
 
-    const float w_pre0gt1 = mulli * sqrtf(kWeight0 * w_0gt1) / (len * 2 + 1);
-    const float w_pre0lt1 = mulli * sqrtf(kWeight1 * w_0lt1) / (len * 2 + 1);
+    const float len2 = len * 2.0f + 1.0f;
+    const float w_pre0gt1 = mulli * sqrtf(kWeight0 * w_0gt1) / len2;
+    const float w_pre0lt1 = mulli * sqrtf(kWeight1 * w_0lt1) / len2;
     const float norm2_0gt1 = w_pre0gt1 * norm1;
     const float norm2_0lt1 = w_pre0lt1 * norm1;
 
@@ -608,7 +610,7 @@ __global__ void MaltaDiffMapLF_Kernel(const float* lum0, const float* lum1, floa
     for (int i = serialind; i < 24*24; i += serialstride){
         int workx = topleftx + i%24; int worky = toplefty + i/24;
         if (workx < 0 || workx >= width || worky < 0 || worky >= height){
-            diffs[i] = 0;
+            diffs[i] = 0.0f;
             continue;
         }
 
@@ -623,12 +625,12 @@ __global__ void MaltaDiffMapLF_Kernel(const float* lum0, const float* lum1, floa
         const float fabs0 = abs(lum0[worky*width + workx]);
 
         // Secondary half-open quadratic objectives.
-        const float too_small = 0.55f * fabs0;
-        const float too_big = 1.05f * fabs0;
+        const float too_small = 0.55 * fabs0;
+        const float too_big = 1.05 * fabs0;
 
-        float impact = 0;
+        float impact = 0.0f;
 
-        if (lum0[worky*width + workx] < 0){
+        if (lum0[worky*width + workx] < 0.0f){
             if (lum1[worky*width + workx] > -too_small){
                 impact = lum1[worky*width + workx] + too_small;
             } else if (lum1[worky*width + workx] < -too_big){
@@ -643,7 +645,7 @@ __global__ void MaltaDiffMapLF_Kernel(const float* lum0, const float* lum1, floa
         }
         impact *= scaler2;
 
-        if (diff < 0){
+        if (diff < 0.0f){
             diffs[i] -= impact;
         } else {
             diffs[i] += impact;

--- a/src/butter/maltaDiff.hpp
+++ b/src/butter/maltaDiff.hpp
@@ -658,8 +658,8 @@ __global__ void MaltaDiffMapLF_Kernel(const float* lum0, const float* lum1, floa
 }
 
 __host__ void MaltaDiffMap(const float* lum0, const float* lum1, float* block_diff_ac, const int width, const int height, const float w_0gt1, const float w_0lt1, const float norm1, hipStream_t stream){
-    const float len = 3.75;
-    const float mulli = 0.39905817637;
+    const float len = 3.75f;
+    const float mulli = 0.39905817637f;
 
     const int th_x = 16;
     const int th_y = 16;
@@ -669,8 +669,8 @@ __host__ void MaltaDiffMap(const float* lum0, const float* lum1, float* block_di
 }
 
 __host__ void MaltaDiffMapLF(const float* lum0, const float* lum1, float* block_diff_ac, const int width, const int height, const float w_0gt1, const float w_0lt1, const float norm1, hipStream_t stream){
-    const float len = 3.75;
-    const float mulli = 0.611612573796;
+    const float len = 3.75f;
+    const float mulli = 0.611612573796f;
 
     const int th_x = 16;
     const int th_y = 16;

--- a/src/butter/maskPsycho.hpp
+++ b/src/butter/maskPsycho.hpp
@@ -9,7 +9,7 @@ __global__ void diffPrecompute_Kernel(float* mem1, float* dst, int width, int he
     if (y >= height) return;
 
     float bias = mul*bias_arg;
-    dst[thx] = sqrtf(mul * abs(mem1[thx]) + bias) - sqrtf(bias);
+    dst[thx] = sqrtf(mul * fabs(mem1[thx]) + bias) - sqrtf(bias);
     //if (thx == 10000) printf("diffprecompute : %f from %f\n", dst[thx], mem1[thx]);
 }
 
@@ -65,7 +65,7 @@ __global__ void fuzzyerrosion_Kernel(float* src, float* dst, int width, int heig
 
     const int kStep = 3;
     float min0 = src[ux];
-    float min1 = 2 * min0;
+    float min1 = 2.0f * min0;
     float min2 = min1;
     if (x >= kStep) {
         float v = src[y*width + x - kStep];
@@ -130,14 +130,14 @@ void MaskPsychoImage(Plane_d* hf1, Plane_d* uhf1, Plane_d* hf2, Plane_d* uhf2, P
     Plane_d temp3 = uhf1[0];
     //Plane_d temp4 = uhf1[1];
 
-    diffPrecompute(mask_xyb0.mem_d, diff0.mem_d, width, height, 6.19424080439, 12.61050594197, stream);
-    diffPrecompute(mask_xyb1.mem_d, diff1.mem_d, width, height, 6.19424080439, 12.61050594197, stream);
+    diffPrecompute(mask_xyb0.mem_d, diff0.mem_d, width, height, 6.19424080439f, 12.61050594197f, stream);
+    diffPrecompute(mask_xyb1.mem_d, diff1.mem_d, width, height, 6.19424080439f, 12.61050594197f, stream);
     Plane_d blurred0 = mask_xyb0;
     Plane_d blurred1 = mask_xyb1;
-    diff0.blur(blurred0, temp3, 2.7, 0., gaussiankernel);
-    diff1.blur(blurred1, temp3, 2.7, 0., gaussiankernel);
+    diff0.blur(blurred0, temp3, 2.7f, 0.0f, gaussiankernel);
+    diff1.blur(blurred1, temp3, 2.7f, 0.0f, gaussiankernel);
     fuzzyerrosion(blurred0.mem_d, mask.mem_d, width, height, stream);
-    L2diff(blurred0.mem_d, blurred1.mem_d, block_diff_ac[1].mem_d, width*height, 10., stream);
+    L2diff(blurred0.mem_d, blurred1.mem_d, block_diff_ac[1].mem_d, width*height, 10.0f, stream);
 }
 
 }

--- a/src/butter/maskPsycho.hpp
+++ b/src/butter/maskPsycho.hpp
@@ -9,7 +9,7 @@ __global__ void diffPrecompute_Kernel(float* mem1, float* dst, int width, int he
     if (y >= height) return;
 
     float bias = mul*bias_arg;
-    dst[thx] = sqrtf(mul * fabs(mem1[thx]) + bias) - sqrtf(bias);
+    dst[thx] = sqrtf(mul * abs(mem1[thx]) + bias) - sqrtf(bias);
     //if (thx == 10000) printf("diffprecompute : %f from %f\n", dst[thx], mem1[thx]);
 }
 

--- a/src/butter/separatefrequencies.hpp
+++ b/src/butter/separatefrequencies.hpp
@@ -127,7 +127,7 @@ namespace butter{
         MaximumClamp(uhf[x], kMaxclampUhf);
         uhf[x] *= 2.69313763794f;
         hf[x] *= 2.155f;
-        AmplifyRangeAroundZero(hf[x], 0.132);
+        AmplifyRangeAroundZero(hf[x], 0.132f);
 
         //printf("res : %f and %f\n", first[x], second[x]);
     }
@@ -190,7 +190,7 @@ namespace butter{
         for (int i = 0; i < 2; i++){
             //original does uhf = hf but hf is already in uhf.
             //next is hf = blur(hf (uhf)) -> hf is now at its place and uhf has the old hf copy
-            uhf[i].blur(hf[i], temp[i], 1.56416327805, 0, gaussiankernel);
+            uhf[i].blur(hf[i], temp[i], 1.56416327805f, 0, gaussiankernel);
 
             if (i == 0){
                 subarray_removerangearound0(hf[i].mem_d, uhf[i].mem_d, width*height, 1.5f, stream);

--- a/src/butter/separatefrequencies.hpp
+++ b/src/butter/separatefrequencies.hpp
@@ -1,10 +1,10 @@
 namespace butter{
 
     __device__ inline void XybLowFreqToVals(float& x, float& y, float& b) {
-        const float xmuli = 33.832837186260;
-        const float ymuli = 14.458268100570;
-        const float bmuli = 49.87984651440;
-        const float y_to_b_muli = -0.362267051518;
+        const float xmuli = 33.832837186260f;
+        const float ymuli = 14.458268100570f;
+        const float bmuli = 49.87984651440f;
+        const float y_to_b_muli = -0.362267051518f;
         b = b + y_to_b_muli * y;
         b = b * bmuli;
         x = x * xmuli;
@@ -22,7 +22,7 @@ namespace butter{
     }
 
     __device__ inline void MaximumClamp(float& v, float maxval) {
-        const float kMul = 0.688059627878;
+        const float kMul = 0.688059627878f;
         if (v >= maxval) {
             v -= maxval;
             v *= kMul;
@@ -35,8 +35,8 @@ namespace butter{
     }
 
     __device__ inline void supressXbyY(float& x, float yval, float yw){
-        const float s = 0.653020556257;
-        const float scaler = s + (yw * (1.0 - s)) / (yw + yval * yval);
+        const float s = 0.653020556257f;
+        const float scaler = s + (yw * (1.0f - s)) / (yw + yval * yval);
         x *= scaler;
     }
 
@@ -119,14 +119,14 @@ namespace butter{
 
         if (x >= width) return;
 
-        const float kMaxclampHf = 28.4691806922;
-        const float kMaxclampUhf = 5.19175294647;
+        const float kMaxclampHf = 28.4691806922f;
+        const float kMaxclampUhf = 5.19175294647f;
 
         MaximumClamp(hf[x], kMaxclampHf);
         uhf[x] -= hf[x];
         MaximumClamp(uhf[x], kMaxclampUhf);
-        uhf[x] *= 2.69313763794;
-        hf[x] *= 2.155;
+        uhf[x] *= 2.69313763794f;
+        hf[x] *= 2.155f;
         AmplifyRangeAroundZero(hf[x], 0.132);
 
         //printf("res : %f and %f\n", first[x], second[x]);
@@ -161,12 +161,12 @@ namespace butter{
         
         for (int i = 0; i < 3; i++){
             //we separate lf to get mf BUT we put mf on hf if i != 2 for later reasons
-            src[i].blur(lf[i], temp[i], 7.15593339443, 0, gaussiankernel);
+            src[i].blur(lf[i], temp[i], 7.15593339443f, 0, gaussiankernel);
 
             if (i == 2){
                 //mf = blur(xyb-lf)
                 subarray(src[i].mem_d, lf[i].mem_d, mf[i].mem_d, width*height, stream);
-                mf[i].blur(temp[i], 3.22489901262, 0, gaussiankernel);
+                mf[i].blur(temp[i], 3.22489901262f, 0, gaussiankernel);
                 break;
             }
             //mf (hf (uhf)) = xyb-lf //mf is stored on hf which is stored in uhf
@@ -174,18 +174,18 @@ namespace butter{
             subarray(src[i].mem_d, lf[i].mem_d, uhf[i].mem_d, width*height, stream);
             //mf = blur(mf (hf (uhf))) //we blur mf BUT mf is on hf which is on uhf. After this, mf is stored in mf but hf is on uhf
             //the real mf is blurred and we avoid the need to copy the unblurred mf to hf (uhf)
-            uhf[i].blur(mf[i], temp[i], 3.22489901262, 0, gaussiankernel);
+            uhf[i].blur(mf[i], temp[i], 3.22489901262f, 0, gaussiankernel);
 
             //hf (uhf) = op(mf, hf (uhf))
             if (i == 0){
-                subarray_removerangearound0(mf[i].mem_d, uhf[i].mem_d, width*height, 0.29, stream); 
+                subarray_removerangearound0(mf[i].mem_d, uhf[i].mem_d, width*height, 0.29f, stream); 
             } else {
-                subarray_amplifyrangearound0(mf[i].mem_d, uhf[i].mem_d, width*height, 0.1, stream);
+                subarray_amplifyrangearound0(mf[i].mem_d, uhf[i].mem_d, width*height, 0.1f, stream);
             }
 
         }
         //using uhf which contains hf in reality
-        supressXbyY(uhf[0].mem_d, uhf[1].mem_d, width*height, 46.0, stream);
+        supressXbyY(uhf[0].mem_d, uhf[1].mem_d, width*height, 46.0f, stream);
 
         for (int i = 0; i < 2; i++){
             //original does uhf = hf but hf is already in uhf.
@@ -193,8 +193,8 @@ namespace butter{
             uhf[i].blur(hf[i], temp[i], 1.56416327805, 0, gaussiankernel);
 
             if (i == 0){
-                subarray_removerangearound0(hf[i].mem_d, uhf[i].mem_d, width*height, 1.5, stream);
-                removerangearound0(uhf[i].mem_d, width*height, 0.04, stream);
+                subarray_removerangearound0(hf[i].mem_d, uhf[i].mem_d, width*height, 1.5f, stream);
+                removerangearound0(uhf[i].mem_d, width*height, 0.04f, stream);
             } else {
                 separateHf_Uhf(lf[i].mem_d, hf[i].mem_d, uhf[i].mem_d, width*height, stream);
             }

--- a/src/butter/separatefrequencies.hpp
+++ b/src/butter/separatefrequencies.hpp
@@ -36,7 +36,7 @@ namespace butter{
 
     __device__ inline void supressXbyY(float& x, float yval, float yw){
         const float s = 0.653020556257f;
-        const float scaler = s + (yw * (1.0f - s)) / (yw + yval * yval);
+        const float scaler = s + (yw * (1.0 - s)) / (yw + yval * yval);
         x *= scaler;
     }
 
@@ -125,8 +125,8 @@ namespace butter{
         MaximumClamp(hf[x], kMaxclampHf);
         uhf[x] -= hf[x];
         MaximumClamp(uhf[x], kMaxclampUhf);
-        uhf[x] *= 2.69313763794f;
-        hf[x] *= 2.155f;
+        uhf[x] *= 2.69313763794;
+        hf[x] *= 2.155;
         AmplifyRangeAroundZero(hf[x], 0.132f);
 
         //printf("res : %f and %f\n", first[x], second[x]);
@@ -161,12 +161,12 @@ namespace butter{
         
         for (int i = 0; i < 3; i++){
             //we separate lf to get mf BUT we put mf on hf if i != 2 for later reasons
-            src[i].blur(lf[i], temp[i], 7.15593339443f, 0, gaussiankernel);
+            src[i].blur(lf[i], temp[i], 7.15593339443f, 0.0f, gaussiankernel);
 
             if (i == 2){
                 //mf = blur(xyb-lf)
                 subarray(src[i].mem_d, lf[i].mem_d, mf[i].mem_d, width*height, stream);
-                mf[i].blur(temp[i], 3.22489901262f, 0, gaussiankernel);
+                mf[i].blur(temp[i], 3.22489901262f, 0.0f, gaussiankernel);
                 break;
             }
             //mf (hf (uhf)) = xyb-lf //mf is stored on hf which is stored in uhf
@@ -174,7 +174,7 @@ namespace butter{
             subarray(src[i].mem_d, lf[i].mem_d, uhf[i].mem_d, width*height, stream);
             //mf = blur(mf (hf (uhf))) //we blur mf BUT mf is on hf which is on uhf. After this, mf is stored in mf but hf is on uhf
             //the real mf is blurred and we avoid the need to copy the unblurred mf to hf (uhf)
-            uhf[i].blur(mf[i], temp[i], 3.22489901262f, 0, gaussiankernel);
+            uhf[i].blur(mf[i], temp[i], 3.22489901262f, 0.0f, gaussiankernel);
 
             //hf (uhf) = op(mf, hf (uhf))
             if (i == 0){
@@ -190,7 +190,7 @@ namespace butter{
         for (int i = 0; i < 2; i++){
             //original does uhf = hf but hf is already in uhf.
             //next is hf = blur(hf (uhf)) -> hf is now at its place and uhf has the old hf copy
-            uhf[i].blur(hf[i], temp[i], 1.56416327805f, 0, gaussiankernel);
+            uhf[i].blur(hf[i], temp[i], 1.56416327805f, 0.0f, gaussiankernel);
 
             if (i == 0){
                 subarray_removerangearound0(hf[i].mem_d, uhf[i].mem_d, width*height, 1.5f, stream);

--- a/src/butter/simplerdiff.hpp
+++ b/src/butter/simplerdiff.hpp
@@ -41,7 +41,7 @@ void diffclamp(float* src1, float* src2, float* dst, int width, float maxclamp, 
 __host__ void sameNoiseLevels(Plane_d p1, Plane_d p2, Plane_d output, Plane_d temp1, Plane_d temp2, const float sigma, const float w, const float maxclamp, float* gaussiankernel){
     //output should not be used because we are going to += it that is why we need 2 temporaries
     diffclamp(p1.mem_d, p2.mem_d, temp1.mem_d, p1.width*p1.height, maxclamp, p1.stream);
-    temp1.blur(temp2, sigma, 0., gaussiankernel);
+    temp1.blur(temp2, sigma, 0.0f, gaussiankernel);
     samenoisediff(temp1.mem_d, output.mem_d, p1.width*p1.height, w, p1.stream);
 }
 
@@ -74,8 +74,8 @@ __global__ void L2AsymDiff_Kernel(float* src1, float* src2, float* dst, int widt
     dst[x] += w_0gt1 * diff * diff;
 
     const float fabs0 = abs(src1[x]);
-    const float too_small = 0.4f * fabs0;
-    const float too_big = 1.0f * fabs0;
+    const float too_small = 0.4 * fabs0;
+    const float too_big = fabs0;
 
     if (src1[x] < 0) {
         if (src2[x] > -too_small) {
@@ -98,8 +98,8 @@ __global__ void L2AsymDiff_Kernel(float* src1, float* src2, float* dst, int widt
 
 void L2AsymDiff(float* src1, float* src2, float* dst, int width, float w_0gt1, float w_0lt1, hipStream_t stream){
     if (w_0gt1 == 0.0f && w_0lt1 == 0.0f) return;
-    w_0gt1 *= 0.8f;
-    w_0lt1 *= 0.8f;
+    w_0gt1 *= 0.8;
+    w_0lt1 *= 0.8;
     int th_x = std::min(256, width);
     int bl_x = (width-1)/th_x + 1;
     L2AsymDiff_Kernel<<<dim3(bl_x), dim3(th_x), 0, stream>>>(src1, src2, dst, width, w_0gt1, w_0lt1);

--- a/src/butter/simplerdiff.hpp
+++ b/src/butter/simplerdiff.hpp
@@ -23,8 +23,8 @@ __global__ void diffclamp_Kernel(float* src1, float* src2, float* dst, int width
 
     if (x >= width) return;
 
-    float v0 = fabs(src1[x]);
-    float v1 = fabs(src2[x]);
+    float v0 = abs(src1[x]);
+    float v1 = abs(src2[x]);
 
     if (v0 > maxclamp) v0 = maxclamp;
     if (v1 > maxclamp) v1 = maxclamp;
@@ -73,7 +73,7 @@ __global__ void L2AsymDiff_Kernel(float* src1, float* src2, float* dst, int widt
     const float diff = src1[x] - src2[x];
     dst[x] += w_0gt1 * diff * diff;
 
-    const float fabs0 = fabs(src1[x]);
+    const float fabs0 = abs(src1[x]);
     const float too_small = 0.4f * fabs0;
     const float too_big = 1.0f * fabs0;
 

--- a/src/butter/simplerdiff.hpp
+++ b/src/butter/simplerdiff.hpp
@@ -23,8 +23,8 @@ __global__ void diffclamp_Kernel(float* src1, float* src2, float* dst, int width
 
     if (x >= width) return;
 
-    float v0 = abs(src1[x]);
-    float v1 = abs(src2[x]);
+    float v0 = fabs(src1[x]);
+    float v1 = fabs(src2[x]);
 
     if (v0 > maxclamp) v0 = maxclamp;
     if (v1 > maxclamp) v1 = maxclamp;
@@ -74,8 +74,8 @@ __global__ void L2AsymDiff_Kernel(float* src1, float* src2, float* dst, int widt
     dst[x] += w_0gt1 * diff * diff;
 
     const float fabs0 = fabs(src1[x]);
-    const float too_small = 0.4 * fabs0;
-    const float too_big = 1.0 * fabs0;
+    const float too_small = 0.4f * fabs0;
+    const float too_big = 1.0f * fabs0;
 
     if (src1[x] < 0) {
         if (src2[x] > -too_small) {
@@ -97,9 +97,9 @@ __global__ void L2AsymDiff_Kernel(float* src1, float* src2, float* dst, int widt
 }
 
 void L2AsymDiff(float* src1, float* src2, float* dst, int width, float w_0gt1, float w_0lt1, hipStream_t stream){
-    if (w_0gt1 == 0 && w_0lt1 == 0) return;
-    w_0gt1 *= 0.8;
-    w_0lt1 *= 0.8;
+    if (w_0gt1 == 0.0f && w_0lt1 == 0.0f) return;
+    w_0gt1 *= 0.8f;
+    w_0lt1 *= 0.8f;
     int th_x = std::min(256, width);
     int bl_x = (width-1)/th_x + 1;
     L2AsymDiff_Kernel<<<dim3(bl_x), dim3(th_x), 0, stream>>>(src1, src2, dst, width, w_0gt1, w_0lt1);

--- a/src/ssimu2/downsample.hpp
+++ b/src/ssimu2/downsample.hpp
@@ -14,7 +14,7 @@ __global__ void downsamplekernel(float3* src, float3* dst, int width, int height
     dst[y * neww + x] += src[min((int)(2*y + 1), (int)(height-1)) * width + min((int)(2*x), (int)(width-1))];
     dst[y * neww + x] += src[min((int)(2*y), (int)(height-1)) * width + min((int)(2*x+1), (int)(width-1))];
     dst[y * neww + x] += src[min((int)(2*y + 1), (int)(height-1)) * width + min((int)(2*x+1), (int)(width-1))];
-    dst[y * neww + x] /= 4;
+    dst[y * neww + x] *= 0.25f;
     //printf("got %f, %f, %f from %f, %f, %f ; %f, %f, %f ; %f, %f, %f ; %f, %f, %f\n", dst[y * neww + x].x, dst[y * neww + x].y, dst[y * neww + x].z, src[min((int)(2*y), (int)(newh-1)) * neww + 2*x].x, src[min((int)(2*y), (int)(newh-1)) * neww + 2*x].y, src[min((int)(2*y), (int)(newh-1)) * neww + 2*x].z, src[min((int)(2*y + 1), (int)(newh-1)) * neww + 2*x].x, src[min((int)(2*y + 1), (int)(newh-1)) * neww + 2*x].y, src[min((int)(2*y + 1), (int)(newh-1)) * neww + 2*x].z, src[min((int)(2*y), (int)(newh-1)) * neww + 2*x + 1].x, src[min((int)(2*y), (int)(newh-1)) * neww + 2*x + 1].y, src[min((int)(2*y), (int)(newh-1)) * neww + 2*x + 1].z, src[min((int)(2*y + 1), (int)(newh-1)) * neww + 2*x + 1].x, src[min((int)(2*y + 1), (int)(newh-1)) * neww + 2*x + 1].y, src[min((int)(2*y + 1), (int)(newh-1)) * neww + 2*x + 1].z);
 }
 

--- a/src/ssimu2/gaussianblur.hpp
+++ b/src/ssimu2/gaussianblur.hpp
@@ -39,8 +39,8 @@ __global__ void verticalBlur_Kernel(float3* src, float3* dst, int width, int hei
     int current_line = x/w;
     int current_column = x%w;
 
-    float tot = 0;
-    float3 out; out.x = 0; out.y = 0; out.z = 0;
+    float tot = 0.0f;
+    float3 out; out.x = out.y = out.z = 0.0f;
     for (int i = max(current_line-GAUSSIANSIZE, 0); i <= min(current_line+GAUSSIANSIZE, h-1); i++){
         out += src[i * w + current_column]*gaussiankernel[GAUSSIANSIZE+i-current_line];
         tot += gaussiankernel[GAUSSIANSIZE+i-current_line];

--- a/src/ssimu2/main.hpp
+++ b/src/ssimu2/main.hpp
@@ -8,7 +8,7 @@
 
 namespace ssimu2{
 
-double ssimu2process(const uint8_t *srcp1[3], const uint8_t *srcp2[3], int stride, int width, int height, float* gaussiankernel, int maxshared, hipStream_t stream){
+float ssimu2process(const uint8_t *srcp1[3], const uint8_t *srcp2[3], int stride, int width, int height, float* gaussiankernel, int maxshared, hipStream_t stream){
 
     int wh = width*height;
     int whs[6] = {wh, ((height-1)/2 + 1)*((width-1)/2 + 1), ((height-1)/4 + 1)*((width-1)/4 + 1), ((height-1)/8 + 1)*((width-1)/8 + 1), ((height-1)/16 + 1)*((width-1)/16 + 1), ((height-1)/32 + 1)*((width-1)/32 + 1)};
@@ -164,7 +164,7 @@ static const VSFrame *VS_CC ssimulacra2GetFrame(int n, int activationReason, voi
             vsapi->getReadPtr(src2, 2),
         };
 
-        double val;
+        float val;
         try{
             val = ssimu2process(srcp1, srcp2, stride, width, height, d->gaussiankernel_d, d->maxshared, d->streams[n%STREAMNUM]);
         } catch (const std::bad_alloc& e){

--- a/src/ssimu2/main.hpp
+++ b/src/ssimu2/main.hpp
@@ -8,7 +8,7 @@
 
 namespace ssimu2{
 
-float ssimu2process(const uint8_t *srcp1[3], const uint8_t *srcp2[3], int stride, int width, int height, float* gaussiankernel, int maxshared, hipStream_t stream){
+double ssimu2process(const uint8_t *srcp1[3], const uint8_t *srcp2[3], int stride, int width, int height, float* gaussiankernel, int maxshared, hipStream_t stream){
 
     int wh = width*height;
     int whs[6] = {wh, ((height-1)/2 + 1)*((width-1)/2 + 1), ((height-1)/4 + 1)*((width-1)/4 + 1), ((height-1)/8 + 1)*((width-1)/8 + 1), ((height-1)/16 + 1)*((width-1)/16 + 1), ((height-1)/32 + 1)*((width-1)/32 + 1)};
@@ -116,7 +116,7 @@ float ssimu2process(const uint8_t *srcp1[3], const uint8_t *srcp2[3], int stride
     }
 
     //step 7 : enjoy !
-    const float ssim = final_score(measure_vec);
+    const double ssim = final_score(measure_vec);
 
     hipEventRecord(event_d, stream); //place an event in the stream at the end of all our operations
     hipEventSynchronize(event_d); //when the event is complete, we know our gpu result is ready!
@@ -266,7 +266,7 @@ static void VS_CC ssimulacra2Create(const VSMap *in, VSMap *out, void *userData,
 
     float gaussiankernel[2*GAUSSIANSIZE+1];
     for (int i = 0; i < 2*GAUSSIANSIZE+1; i++){
-        gaussiankernel[i] = std::exp(-(GAUSSIANSIZE-i)*(GAUSSIANSIZE-i)/(2*SIGMA*SIGMA))/(std::sqrt(2*PI*SIGMA*SIGMA));
+        gaussiankernel[i] = std::exp(-(GAUSSIANSIZE-i)*(GAUSSIANSIZE-i)/(2*SIGMA*SIGMA))/(std::sqrt(TAU*SIGMA*SIGMA));
     }
 
     data->maxshared = devattr.sharedMemPerBlock;

--- a/src/ssimu2/main.hpp
+++ b/src/ssimu2/main.hpp
@@ -116,7 +116,7 @@ double ssimu2process(const uint8_t *srcp1[3], const uint8_t *srcp2[3], int strid
     }
 
     //step 7 : enjoy !
-    const double ssim = final_score(measure_vec);
+    const float ssim = final_score(measure_vec);
 
     hipEventRecord(event_d, stream); //place an event in the stream at the end of all our operations
     hipEventSynchronize(event_d); //when the event is complete, we know our gpu result is ready!
@@ -164,7 +164,7 @@ static const VSFrame *VS_CC ssimulacra2GetFrame(int n, int activationReason, voi
             vsapi->getReadPtr(src2, 2),
         };
 
-        float val;
+        double val;
         try{
             val = ssimu2process(srcp1, srcp2, stride, width, height, d->gaussiankernel_d, d->maxshared, d->streams[n%STREAMNUM]);
         } catch (const std::bad_alloc& e){

--- a/src/ssimu2/makeXYB.hpp
+++ b/src/ssimu2/makeXYB.hpp
@@ -31,17 +31,17 @@ __device__ inline void linear_rgb_to_xyb(float3& a){
     const float abs_bias = -0.1559542025327239f;
     opsin_absorbance(a);
     //printf("from %f to %f\n", a.x, cbrtf(a.x*((int)(a.x >= 0))));
-    a.x = cbrtf(a.x * ((int)(a.x >= 0.0f))) + abs_bias;
-    a.y = cbrtf(a.y * ((int)(a.y >= 0.0f))) + abs_bias;
-    a.z = cbrtf(a.z * ((int)(a.z >= 0.0f))) + abs_bias;
+    a.x = cbrtf(a.x * ((int)(a.x >= 0))) + abs_bias;
+    a.y = cbrtf(a.y * ((int)(a.y >= 0))) + abs_bias;
+    a.z = cbrtf(a.z * ((int)(a.z >= 0))) + abs_bias;
     //printf("got %f, %f, %f\n", a.x, a.y, a.z);
     mixed_to_xyb(a);
 }
 
-__device__ inline void make_positive_xyb(float3& a){
-    a.z = (a.z - a.y) + 0.55f;
-    a.x = a.x * 14.0f + 0.42f;
-    a.y += 0.01f;
+__device__ inline void make_positive_xyb(float3& a) {
+    a.z = (a.z - a.y) + 0.55;
+    a.x = a.x * 14.0f + 0.42;  
+    a.y += 0.01;
 }
 
 __device__ inline void rgb_to_positive_xyb_d(float3& a){
@@ -49,11 +49,11 @@ __device__ inline void rgb_to_positive_xyb_d(float3& a){
     make_positive_xyb(a);
 }
 
-__device__ inline void rgb_to_linrgbfunc(float& a){
-    if (a > 0.04045f){
-        a = powf(((a+0.055f)/(1.055f)), 2.4f);
+__device__ inline void rgb_to_linrgbfunc(float& a) {
+    if (a > 0.04045f) {
+        a = powf((a + 0.055) * (1.0 / 1.055), 2.4f);
     } else {
-        a = a/12.92f;
+        a *= (1.0 / 12.92);
     }
 }
 

--- a/src/ssimu2/makeXYB.hpp
+++ b/src/ssimu2/makeXYB.hpp
@@ -23,7 +23,7 @@ __device__ inline void opsin_absorbance(float3& a){
 }
 
 __device__ inline void mixed_to_xyb(float3& a){
-    a.x = 0.5 * (a.x - a.y);
+    a.x = 0.5f * (a.x - a.y);
     a.y = a.x + a.y;
 }
 
@@ -40,7 +40,7 @@ __device__ inline void linear_rgb_to_xyb(float3& a){
 
 __device__ inline void make_positive_xyb(float3& a){
     a.z = (a.z - a.y) + 0.55f;
-    a.x = a.x * 14.f + 0.42f;
+    a.x = a.x * 14.0f + 0.42f;
     a.y += 0.01f;
 }
 
@@ -53,7 +53,7 @@ __device__ inline void rgb_to_linrgbfunc(float& a){
     if (a > 0.04045f){
         a = powf(((a+0.055f)/(1.055f)), 2.4f);
     } else {
-        a = a/12.92;
+        a = a/12.92f;
     }
 }
 

--- a/src/ssimu2/makeXYB.hpp
+++ b/src/ssimu2/makeXYB.hpp
@@ -3,20 +3,20 @@
 
 __device__ inline void opsin_absorbance(float3& a){
     float3 out;
-    const float opsin_bias = 0.0037930734;
-    out.x = fmaf(0.30, a.x,
-    fmaf(0.622, a.y,
-    fmaf(0.078, a.z,
+    const float opsin_bias = 0.0037930734f;
+    out.x = fmaf(0.30f, a.x,
+    fmaf(0.622f, a.y,
+    fmaf(0.078f, a.z,
     opsin_bias)));
 
-    out.y = fmaf(0.23, a.x,
-    fmaf(0.692, a.y,
-    fmaf(0.078, a.z,
+    out.y = fmaf(0.23f, a.x,
+    fmaf(0.692f, a.y,
+    fmaf(0.078f, a.z,
     opsin_bias)));
 
-    out.z = fmaf(0.24342269, a.x,
-    fmaf(0.20476745, a.y,
-    fmaf(0.55180986, a.z,
+    out.z = fmaf(0.24342269f, a.x,
+    fmaf(0.20476745f, a.y,
+    fmaf(0.55180986f, a.z,
     opsin_bias)));
 
     a = out;
@@ -28,20 +28,20 @@ __device__ inline void mixed_to_xyb(float3& a){
 }
 
 __device__ inline void linear_rgb_to_xyb(float3& a){
-    const float abs_bias = -0.1559542025327239;
+    const float abs_bias = -0.1559542025327239f;
     opsin_absorbance(a);
     //printf("from %f to %f\n", a.x, cbrtf(a.x*((int)(a.x >= 0))));
-    a.x = cbrtf(a.x * ((int)(a.x >= 0))) + abs_bias;
-    a.y = cbrtf(a.y * ((int)(a.y >= 0))) + abs_bias;
-    a.z = cbrtf(a.z * ((int)(a.z >= 0))) + abs_bias;
+    a.x = cbrtf(a.x * ((int)(a.x >= 0.0f))) + abs_bias;
+    a.y = cbrtf(a.y * ((int)(a.y >= 0.0f))) + abs_bias;
+    a.z = cbrtf(a.z * ((int)(a.z >= 0.0f))) + abs_bias;
     //printf("got %f, %f, %f\n", a.x, a.y, a.z);
     mixed_to_xyb(a);
 }
 
 __device__ inline void make_positive_xyb(float3& a){
-    a.z = (a.z - a.y) + 0.55;
-    a.x = a.x * 14 + 0.42;
-    a.y += 0.01;
+    a.z = (a.z - a.y) + 0.55f;
+    a.x = a.x * 14.f + 0.42f;
+    a.y += 0.01f;
 }
 
 __device__ inline void rgb_to_positive_xyb_d(float3& a){
@@ -50,8 +50,8 @@ __device__ inline void rgb_to_positive_xyb_d(float3& a){
 }
 
 __device__ inline void rgb_to_linrgbfunc(float& a){
-    if (a > 0.04045){
-        a = powf(((a+0.055)/(1+0.055)), 2.4f);
+    if (a > 0.04045f){
+        a = powf(((a+0.055f)/(1.055f)), 2.4f);
     } else {
         a = a/12.92;
     }

--- a/src/ssimu2/score.hpp
+++ b/src/ssimu2/score.hpp
@@ -333,7 +333,7 @@ const float weights[108] = {
 
 float final_score(std::vector<float> scores){
     //score has to be of size 108
-    float ssim = 0;
+    float ssim = 0.0f;
     for (int i = 0; i < 108; i++){
         ssim = fmaf(weights[i], scores[i], ssim);
     }

--- a/src/ssimu2/score.hpp
+++ b/src/ssimu2/score.hpp
@@ -337,13 +337,13 @@ float final_score(std::vector<float> scores){
     for (int i = 0; i < 108; i++){
         ssim = fmaf(weights[i], scores[i], ssim);
     }
-    ssim *= 0.9562382616834844f;
-    ssim = (6.248496625763138e-5f * ssim * ssim) * ssim +
-        2.326765642916932f * ssim -
-        0.020884521182843837f * ssim * ssim;
+    ssim *= 0.9562382616834844;
+    ssim = (6.248496625763138e-5 * ssim * ssim) * ssim +
+        2.326765642916932 * ssim -
+        0.020884521182843837 * ssim * ssim;
     
     if (ssim > 0.0) {
-        ssim = std::powf(ssim, 0.6276336467831387f) * -10.0f + 100.0f;
+        ssim = std::pow(ssim, 0.6276336467831387) * -10.0 + 100.0;
     } else {
         ssim = 100.0f;
     }

--- a/src/ssimu2/score.hpp
+++ b/src/ssimu2/score.hpp
@@ -16,26 +16,26 @@ __global__ void sumreduce(float3* dst, float3* src, int bl_x){
     float3* sumd4 = sharedmem+5*blockDim.x; //size sizeof(float3)*threadnum
 
     if (x >= bl_x){
-        sumssim1[thx].x = 0;
-        sumssim4[thx].x = 0;
-        suma1[thx].x = 0;
-        suma4[thx].x = 0;
-        sumd1[thx].x = 0;
-        sumd4[thx].x = 0;
+        sumssim1[thx].x = 0.0f;
+        sumssim4[thx].x = 0.0f;
+        suma1[thx].x = 0.0f;
+        suma4[thx].x = 0.0f;
+        sumd1[thx].x = 0.0f;
+        sumd4[thx].x = 0.0f;
         
-        sumssim1[thx].y = 0;
-        sumssim4[thx].y = 0;
-        suma1[thx].y = 0;
-        suma4[thx].y = 0;
-        sumd1[thx].y = 0;
-        sumd4[thx].y = 0;
+        sumssim1[thx].y = 0.0f;
+        sumssim4[thx].y = 0.0f;
+        suma1[thx].y = 0.0f;
+        suma4[thx].y = 0.0f;
+        sumd1[thx].y = 0.0f;
+        sumd4[thx].y = 0.0f;
         
-        sumssim1[thx].z = 0;
-        sumssim4[thx].z = 0;
-        suma1[thx].z = 0;
-        suma4[thx].z = 0;
-        sumd1[thx].z = 0;
-        sumd4[thx].z = 0;
+        sumssim1[thx].z = 0.0f;
+        sumssim4[thx].z = 0.0f;
+        suma1[thx].z = 0.0f;
+        suma4[thx].z = 0.0f;
+        sumd1[thx].z = 0.0f;
+        sumd4[thx].z = 0.0f;
     } else {
         sumssim1[thx] = src[x];
         sumssim4[thx] = src[x + bl_x];
@@ -93,26 +93,26 @@ __global__ void allscore_map_Kernel(float3* dst, float3* im1, float3* im2, float
         const float3 m22 = m2*m2;
         const float3 m12 = m1*m2;
         const float3 m_diff = m1-m2;
-        const float3 num_m = fmaf(m_diff, m_diff*-1., 1.0);
-        const float3 num_s = fmaf(s12[x] - m12, 2.0, 0.0009);
-        const float3 denom_s = (s11[x] - m11) + (s22[x] - m22) + 0.0009;
-        d0 = max(1.0 - ((num_m * num_s)/denom_s), 0.);
+        const float3 num_m = fmaf(m_diff, m_diff*-1.0f, 1.0f);
+        const float3 num_s = fmaf(s12[x] - m12, 2.0f, 0.0009f);
+        const float3 denom_s = (s11[x] - m11) + (s22[x] - m22) + 0.0009f;
+        d0 = max(1.0f - ((num_m * num_s)/denom_s), 0.0f);
 
         //edge diff
-        const float3 v1 = (abs(im2[x] - mu2[x])+1.) / (abs(im1[x] - mu1[x])+1.) - 1.;
-        const float3 artifact = max(v1, 0);
-        const float3 detailloss = max(v1*-1, 0);
+        const float3 v1 = (abs(im2[x] - mu2[x])+1.0f) / (abs(im1[x] - mu1[x])+1.0f) - 1.0f;
+        const float3 artifact = max(v1, 0.0f);
+        const float3 detailloss = max(v1*-1.0f, 0.0f);
         d1 = artifact; d2 = detailloss;
     } else {
-        d0.x = 0;
-        d0.y = 0;
-        d0.z = 0;
-        d1.x = 0;
-        d1.y = 0;
-        d1.z = 0;
-        d2.x = 0;
-        d2.y = 0;
-        d2.z = 0;
+        d0.x = 0.0f;
+        d0.y = 0.0f;
+        d0.z = 0.0f;
+        d1.x = 0.0f;
+        d1.y = 0.0f;
+        d1.z = 0.0f;
+        d2.x = 0.0f;
+        d2.y = 0.0f;
+        d2.z = 0.0f;
     }
 
     sumssim1[thx] = d0;
@@ -149,7 +149,7 @@ __global__ void allscore_map_Kernel(float3* dst, float3* im1, float3* im2, float
 std::vector<float3> allscore_map(float3* im1, float3* im2, float3* mu1, float3* mu2, float3* s11, float3* s22, float3* s12, float3* temp, int basewidth, int baseheight, int maxshared, hipEvent_t event_d, hipStream_t stream){
     //output is {normssim1scale1, normssim4scale1, norma1scale1, norma4scale1, normad1scale1, normd4scale1, norm1scale2, ...}
     std::vector<float3> result(2*6*3);
-    for (int i = 0; i < 2*6*3; i++) {result[i].x = 0; result[i].y = 0; result[i].z = 0;}
+    for (int i = 0; i < 2*6*3; i++) {result[i].x = 0.0f; result[i].y = 0.0f; result[i].z = 0.0f;}
 
     int w = basewidth;
     int h = baseheight;
@@ -212,123 +212,123 @@ std::vector<float3> allscore_map(float3* im1, float3* im2, float3* mu1, float3* 
     free(hostback);
 
     for (int i = 0; i < 18; i++){
-        result[2*i+1].x = std::sqrt(std::sqrt(result[2*i+1].x));
-        result[2*i+1].y = std::sqrt(std::sqrt(result[2*i+1].y));
-        result[2*i+1].z = std::sqrt(std::sqrt(result[2*i+1].z));
+        result[2*i+1].x = std::sqrtf(std::sqrtf(result[2*i+1].x));
+        result[2*i+1].y = std::sqrtf(std::sqrtf(result[2*i+1].y));
+        result[2*i+1].z = std::sqrtf(std::sqrtf(result[2*i+1].z));
     } //completing 4th norm
 
     return result;
 }
 
 const float weights[108] = {
-    0.0,
-    0.0007376606707406586,
-    0.0,
-    0.0,
-    0.0007793481682867309,
-    0.0,
-    0.0,
-    0.0004371155730107379,
-    0.0,
-    1.1041726426657346,
-    0.00066284834129271,
-    0.00015231632783718752,
-    0.0,
-    0.0016406437456599754,
-    0.0,
-    1.8422455520539298,
-    11.441172603757666,
-    0.0,
-    0.0007989109436015163,
-    0.000176816438078653,
-    0.0,
-    1.8787594979546387,
-    10.94906990605142,
-    0.0,
-    0.0007289346991508072,
-    0.9677937080626833,
-    0.0,
-    0.00014003424285435884,
-    0.9981766977854967,
-    0.00031949755934435053,
-    0.0004550992113792063,
-    0.0,
-    0.0,
-    0.0013648766163243398,
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-    7.466890328078848,
-    0.0,
-    17.445833984131262,
-    0.0006235601634041466,
-    0.0,
-    0.0,
-    6.683678146179332,
-    0.00037724407979611296,
-    1.027889937768264,
-    225.20515300849274,
-    0.0,
-    0.0,
-    19.213238186143016,
-    0.0011401524586618361,
-    0.001237755635509985,
-    176.39317598450694,
-    0.0,
-    0.0,
-    24.43300999870476,
-    0.28520802612117757,
-    0.0004485436923833408,
-    0.0,
-    0.0,
-    0.0,
-    34.77906344483772,
-    44.835625328877896,
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-    0.0008680556573291698,
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-    0.0005313191874358747,
-    0.0,
-    0.00016533814161379112,
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-    0.0,
-    0.0004179171803251336,
-    0.0017290828234722833,
-    0.0,
-    0.0020827005846636437,
-    0.0,
-    0.0,
-    8.826982764996862,
-    23.19243343998926,
-    0.0,
-    95.1080498811086,
-    0.9863978034400682,
-    0.9834382792465353,
-    0.0012286405048278493,
-    171.2667255897307,
-    0.9807858872435379,
-    0.0,
-    0.0,
-    0.0,
-    0.0005130064588990679,
-    0.0,
-    0.00010854057858411537,
+    0.0f,
+    0.0007376606707406586f,
+    0.0f,
+    0.0f,
+    0.0007793481682867309f,
+    0.0f,
+    0.0f,
+    0.0004371155730107379f,
+    0.0f,
+    1.1041726426657346f,
+    0.00066284834129271f,
+    0.00015231632783718752f,
+    0.0f,
+    0.0016406437456599754f,
+    0.0f,
+    1.8422455520539298f,
+    11.441172603757666f,
+    0.0f,
+    0.0007989109436015163f,
+    0.000176816438078653f,
+    0.0f,
+    1.8787594979546387f,
+    10.94906990605142f,
+    0.0f,
+    0.0007289346991508072f,
+    0.9677937080626833f,
+    0.0f,
+    0.00014003424285435884f,
+    0.9981766977854967f,
+    0.00031949755934435053f,
+    0.0004550992113792063f,
+    0.0f,
+    0.0f,
+    0.0013648766163243398f,
+    0.0f,
+    0.0f,
+    0.0f,
+    0.0f,
+    0.0f,
+    7.466890328078848f,
+    0.0f,
+    17.445833984131262f,
+    0.0006235601634041466f,
+    0.0f,
+    0.0f,
+    6.683678146179332f,
+    0.00037724407979611296f,
+    1.027889937768264f,
+    225.20515300849274f,
+    0.0f,
+    0.0f,
+    19.213238186143016f,
+    0.0011401524586618361f,
+    0.001237755635509985f,
+    176.39317598450694f,
+    0.0f,
+    0.0f,
+    24.43300999870476f,
+    0.28520802612117757f,
+    0.0004485436923833408f,
+    0.0f,
+    0.0f,
+    0.0f,
+    34.77906344483772f,
+    44.835625328877896f,
+    0.0f,
+    0.0f,
+    0.0f,
+    0.0f,
+    0.0f,
+    0.0f,
+    0.0f,
+    0.0f,
+    0.0008680556573291698f,
+    0.0f,
+    0.0f,
+    0.0f,
+    0.0f,
+    0.0f,
+    0.0005313191874358747f,
+    0.0f,
+    0.00016533814161379112f,
+    0.0f,
+    0.0f,
+    0.0f,
+    0.0f,
+    0.0f,
+    0.0004179171803251336f,
+    0.0017290828234722833f,
+    0.0f,
+    0.0020827005846636437f,
+    0.0f,
+    0.0f,
+    8.826982764996862f,
+    23.19243343998926f,
+    0.0f,
+    95.1080498811086f,
+    0.9863978034400682f,
+    0.9834382792465353f,
+    0.0012286405048278493f,
+    171.2667255897307f,
+    0.9807858872435379f,
+    0.0f,
+    0.0f,
+    0.0f,
+    0.0005130064588990679f,
+    0.0f,
+    0.00010854057858411537f,
 };
 
 float final_score(std::vector<float> scores){
@@ -337,15 +337,15 @@ float final_score(std::vector<float> scores){
     for (int i = 0; i < 108; i++){
         ssim = fmaf(weights[i], scores[i], ssim);
     }
-    ssim *= 0.9562382616834844;
-    ssim = (6.248496625763138e-5 * ssim * ssim) * ssim +
-        2.326765642916932 * ssim -
-        0.020884521182843837 * ssim * ssim;
+    ssim *= 0.9562382616834844f;
+    ssim = (6.248496625763138e-5f * ssim * ssim) * ssim +
+        2.326765642916932f * ssim -
+        0.020884521182843837f * ssim * ssim;
     
     if (ssim > 0.0) {
-        ssim = std::pow(ssim, 0.6276336467831387) * -10.0 + 100.0;
+        ssim = std::powf(ssim, 0.6276336467831387f) * -10.0f + 100.0f;
     } else {
-        ssim = 100.0;
+        ssim = 100.0f;
     }
 
     return ssim;

--- a/src/util/float3operations.hpp
+++ b/src/util/float3operations.hpp
@@ -1,7 +1,7 @@
 #ifndef FLOAT3OPHPP
 #define FLOAT3OPHPP
 
-__device__ __host__ void inline operator/=(float3& a, float3& b){
+__device__ __host__ void inline operator/=(float3& a, const float3& b){
     a.x /= b.x;
     a.y /= b.y;
     a.z /= b.z;
@@ -67,9 +67,9 @@ __device__ __host__ float3 inline fmaf(const float3& a, const float& b, const fl
 }
 __device__ __host__ float3 inline abs(const float3& a){
     float3 out;
-    out.x = abs(a.x);
-    out.y = abs(a.y);
-    out.z = abs(a.z);
+    out.x = fabsf(a.x);
+    out.y = fabsf(a.y);
+    out.z = fabsf(a.z);
     return out;
 }
 

--- a/src/util/preprocessor.hpp
+++ b/src/util/preprocessor.hpp
@@ -68,6 +68,7 @@ if (err_hip != hipSuccess)\
 #define STREAMNUM 29
 #define GAUSSIANSIZE 10
 #define SIGMA 1.5f
-#define PI 3.14159265359
+#define PI  3.14159265359f
+#define TAU 6.28318530718f
 
 #endif

--- a/src/util/preprocessor.hpp
+++ b/src/util/preprocessor.hpp
@@ -68,7 +68,7 @@ if (err_hip != hipSuccess)\
 #define STREAMNUM 29
 #define GAUSSIANSIZE 10
 #define SIGMA 1.5f
-#define PI  3.14159265359f
-#define TAU 6.28318530718f
+#define PI  3.14159265359
+#define TAU 6.28318530718
 
 #endif


### PR DESCRIPTION
Considering the final results and operations on the GPU are meant to be single precision, it doesn't make much sense to do some with double precision(as that information gets lost anyway), by making it all single precision it's slightly faster.
I also noticed sometimes abs was used instead of fabs or fabsf, which i replaced with the float versions(unless this was intentional or gets overloaded?).

If there's anything wrong with this, let me know!